### PR TITLE
Raise an error if the mediaContent service URL isn't there

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    promostandards-client (0.5.5)
+    promostandards-client (0.6.0)
       httparty
       savon (~> 2.12.0)
 

--- a/lib/promostandards/client.rb
+++ b/lib/promostandards/client.rb
@@ -1,5 +1,6 @@
 require_relative 'meta_api/client'
 require 'promostandards/client/version'
+require 'promostandards/client/no_service_url_error'
 require 'savon'
 require 'promostandards/primary_image_extractor'
 
@@ -61,6 +62,7 @@ module PromoStandards
     end
 
     def get_primary_image(product_id)
+      raise Promostandards::Client::NoServiceUrlError, 'Media content service URL not set!' unless @media_content_service_url
       client = build_savon_client_for_media(@media_content_service_url)
       response = client.call('GetMediaContentRequest',
         message: {

--- a/lib/promostandards/client/no_service_url_error.rb
+++ b/lib/promostandards/client/no_service_url_error.rb
@@ -1,0 +1,1 @@
+class Promostandards::Client::NoServiceUrlError < StandardError; end

--- a/lib/promostandards/client/version.rb
+++ b/lib/promostandards/client/version.rb
@@ -1,5 +1,5 @@
 module Promostandards
   module Client
-    VERSION = "0.5.5"
+    VERSION = "0.6.0"
   end
 end

--- a/spec/promostandards/client_spec.rb
+++ b/spec/promostandards/client_spec.rb
@@ -1,14 +1,13 @@
 RSpec.describe Promostandards::Client do
-  let(:ps_client) do
-    ps_config = {
+  let(:ps_config) do
+    {
       access_id: 'access_id',
       password: 'password',
       product_data_service_url: 'https://psproductdata100.pcna.online/',
       media_content_service_url: 'https://psmediacontent110.pcna.online/'
     }
-    PromoStandards::Client.new ps_config
   end
-
+  let(:ps_client) { PromoStandards::Client.new ps_config }
   let(:savon_client) { double('SavonClient') }
 
   before do
@@ -253,6 +252,15 @@ RSpec.describe Promostandards::Client do
           }
         }
       })
+    end
+
+    it 'raises an exception when the service URL is not available' do
+      ps_config[:media_content_service_url] = nil
+      ps_client = PromoStandards::Client.new ps_config
+
+      expect do
+        ps_client.get_primary_image 'product_id'
+      end.to raise_error Promostandards::Client::NoServiceUrlError
     end
 
     it 'ensures the structure of the message body' do


### PR DESCRIPTION
It's possible that some suppliers might not have media content services
set up yet. So we allow instantiation of the client, but when
the get_primary_image method is called we need to throw an error.

- Create a new NoServiceUrlError
- In get_primary_image, raise this error if the URL isn't there