### PR TITLE
Collect and show all errors at once

### DIFF
--- a/test_ps_services.rb
+++ b/test_ps_services.rb
@@ -3,12 +3,17 @@ require 'parallel'
 require 'colorize'
 require 'pry'
 
-def print_data(service_host, product = {}, image = {}, fob_points = {}, prices = {})
-  puts "For #{service_host}".colorize(:green)
-  p "Product ID - #{product[:product_id]}"
-  p "Product name - #{product[:product_name]}"
-  p "Product description - #{product[:description]}"
-  p "Product primary image - #{image ? image[:url] : nil}"
+def print_data(service_host, product = {}, image = {}, fob_points = {}, prices = {}, errors=[])
+  puts "\nFor #{service_host}".colorize(:green)
+  begin
+    p "Product ID - #{product[:product_id]}"
+    p "Product name - #{product[:product_name]}"
+    p "Product description - #{product[:description]}"
+    p "Product primary image - #{image ? image[:url] : nil}"
+    puts "Errors:\n- #{errors.join("\n- ")}".colorize(:red) unless errors.empty?
+  rescue
+    puts "❌ Something went wrong"
+  end
 end
 
 # Requires a ps_configs.yml file. See ps_configs.yml.example
@@ -16,30 +21,31 @@ end
 ps_configs = YAML::load_file(File.join(__dir__, 'ps_configs.yml'))
 
 Parallel.each(ps_configs) do |ps_config|
+  errors = []
   service_host = URI.parse(ps_config[:product_data_service_url]).host
   client = PromoStandards::Client.new ps_config
   begin
     product_ids = client.get_sellable_product_ids
   rescue
-    puts "Failed to get products ids from #{service_host}".colorize(:red)
+    errors << "Failed to get products ids from #{service_host}"
     next
   end
   sample_product_id = product_ids.sample
   begin
     product = client.get_product_data sample_product_id
   rescue
-    puts "Failed to get product data from #{service_host}".colorize(:red)
+    errors << "Failed to get product data from #{service_host}"
   end
   begin
     image = client.get_primary_image sample_product_id
   rescue
-    puts "Failed to get image data from #{service_host}".colorize(:red)
+    errors << "Failed to get image data from #{service_host}"
   end
 
   begin
     fob_points = client.get_fob_points sample_product_id
   rescue
-    puts "Failed to get fob points data from #{service_host}".colorize(:red)
+    errors << "Failed to get fob points data from #{service_host}"
   end
 
   fob_id_for_price = if fob_points.is_a?(Hash)
@@ -51,7 +57,7 @@ Parallel.each(ps_configs) do |ps_config|
   begin
     prices = client.get_prices(sample_product_id, fob_id_for_price) if fob_id_for_price
   rescue
-    puts "Failed to get price data from #{service_host}".colorize(:red)
+    errors << "Failed to get price data from #{service_host}"
   end
-  print_data(service_host, product, image, fob_points, prices)
+  print_data(service_host, product, image, fob_points, prices, errors)
 end

--- a/test_ps_services.rb
+++ b/test_ps_services.rb
@@ -27,7 +27,8 @@ Parallel.each(ps_configs) do |ps_config|
   begin
     product_ids = client.get_sellable_product_ids
   rescue
-    errors << "Failed to get products ids from #{service_host}"
+    puts "\nFor #{service_host}".colorize(:green)
+    puts "Errors:\n- Failer to get products ids from #{service_host}".colorize(:red)
     next
   end
   sample_product_id = product_ids.sample


### PR DESCRIPTION
Instead of showing errors as they happen, it helps to have all outputs
for a supplier at one place.